### PR TITLE
Interactive slide deck with Express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+backend/meeting.db
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# Accounting_POD
-Weekly meeting records and slides - interactive
+# Accounting POD Slide Deck
+
+This project provides an interactive slide deck for weekly Accounting POD meetings using **Reveal.js** and a simple **Express** backend with **SQLite** for data storage.
+
+## Setup
+
+1. Install Node.js dependencies (internet access required):
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+3. (Optional) Seed sample data:
+   ```bash
+   node backend/seed.js
+   ```
+4. Open your browser at [http://localhost:3000](http://localhost:3000) to view the slides.
+
+## Project Structure
+
+- `backend/` – Express server and SQLite database setup.
+- `slides/` – Reveal.js HTML slide templates.
+- `assets/` – Icons and images.
+
+## Adding Content
+
+- Update the database tables (`progress`, `action_items`, `priorities`, `notes`) via the API endpoints or using a SQLite editor.
+- Modify slide templates in `slides/index.html` to adjust layout or color scheme.
+

--- a/assets/readme.txt
+++ b/assets/readme.txt
@@ -1,0 +1,1 @@
+placeholder for icons

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,53 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const dbPath = path.join(__dirname, 'meeting.db');
+
+const db = new sqlite3.Database(dbPath);
+
+function init() {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS progress (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      update_text TEXT,
+      team_member TEXT,
+      status TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );`);
+    db.run(`CREATE TABLE IF NOT EXISTS action_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_text TEXT,
+      team_member TEXT,
+      status TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );`);
+    db.run(`CREATE TABLE IF NOT EXISTS challenges (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      challenge_text TEXT,
+      team_member TEXT,
+      status TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );`);
+    db.run(`CREATE TABLE IF NOT EXISTS notes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      note_text TEXT,
+      team_member TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );`);
+    db.run(`CREATE TABLE IF NOT EXISTS priorities (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      topic TEXT,
+      team_member TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );`);
+  });
+}
+
+function all(table, cb) {
+  db.all(`SELECT * FROM ${table} ORDER BY created_at DESC`, cb);
+}
+
+function addNote(text, member, cb) {
+  db.run('INSERT INTO notes(note_text, team_member) VALUES (?, ?)', [text, member], cb);
+}
+
+module.exports = { db, init, all, addNote };

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,10 @@
+const { db, init } = require('./db');
+init();
+
+db.serialize(() => {
+  db.run("INSERT INTO progress(update_text, team_member, status) VALUES ('Closed Q2 books', 'Alice', 'Done');");
+  db.run("INSERT INTO action_items(item_text, team_member, status) VALUES ('Prepare budget report', 'Bob', 'In Progress');");
+  db.run("INSERT INTO challenges(challenge_text, team_member, status) VALUES ('Year-end backlog', 'Diane', 'Open');");
+  db.run("INSERT INTO priorities(topic, team_member) VALUES ('Audit preparation', 'Carol');");
+  console.log('Seed data inserted');
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const path = require('path');
+const db = require('./db');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/assets', express.static(path.join(__dirname, '..', 'assets')));
+app.use('/', express.static(path.join(__dirname, '..', 'slides')));
+
+db.init();
+
+app.get('/api/progress', (req, res) => {
+  db.all('progress', (err, rows) => {
+    if (err) return res.status(500).json({error: err});
+    res.json(rows);
+  });
+});
+
+app.get('/api/actionItems', (req, res) => {
+  db.all('action_items', (err, rows) => {
+    if (err) return res.status(500).json({error: err});
+    res.json(rows);
+  });
+});
+
+app.get('/api/challenges', (req, res) => {
+  db.all('challenges', (err, rows) => {
+    if (err) return res.status(500).json({error: err});
+    res.json(rows);
+  });
+});
+
+app.get('/api/priorities', (req, res) => {
+  db.all('priorities', (err, rows) => {
+    if (err) return res.status(500).json({error: err});
+    res.json(rows);
+  });
+});
+
+app.get('/api/notes', (req, res) => {
+  db.all('notes', (err, rows) => {
+    if (err) return res.status(500).json({error: err});
+    res.json(rows);
+  });
+});
+
+app.post('/api/notes', (req, res) => {
+  const { note_text, team_member } = req.body;
+  db.addNote(note_text, team_member, function(err) {
+    if (err) return res.status(500).json({error: err});
+    res.json({ success: true });
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server started on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "accounting_pod",
+  "version": "1.0.0",
+  "description": "Weekly meeting records and slides - interactive",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node backend/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/slides/index.html
+++ b/slides/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Accounting POD Weekly Meeting</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/theme/white.css">
+  <style>
+    :root {
+      --navy: #001f3f;
+      --light-blue: #7FDBFF;
+      --gray: #AAAAAA;
+    }
+    body { background-color: white; }
+    .reveal section { color: var(--navy); }
+    .progress-section {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .note-area { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+      <section>
+        <h2>Weekly Progress</h2>
+        <div id="progress" class="progress-section"></div>
+        <textarea id="noteProgress" class="note-area" placeholder="Add notes here..."></textarea>
+      </section>
+      <section>
+        <h2>Challenges</h2>
+        <div id="challenges" class="progress-section"></div>
+        <textarea id="noteChallenges" class="note-area" placeholder="Add notes here..."></textarea>
+      </section>
+      <section>
+        <h2>Action Items</h2>
+        <div id="actionItems" class="progress-section"></div>
+        <textarea id="noteActions" class="note-area" placeholder="Add notes here..."></textarea>
+      </section>
+      <section>
+        <h2>Weekly Priorities</h2>
+        <div id="priorities" class="progress-section"></div>
+        <textarea id="notePriorities" class="note-area" placeholder="Add notes here..."></textarea>
+      </section>
+    </div>
+  </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.min.js"></script>
+  <script>
+    Reveal.initialize();
+    const progressEl = document.getElementById('progress');
+    const actionEl = document.getElementById('actionItems');
+    const prioritiesEl = document.getElementById('priorities');
+    const challengesEl = document.getElementById('challenges');
+
+    fetch('/api/progress').then(r => r.json()).then(data => {
+      data.forEach(p => {
+        const div = document.createElement('div');
+        div.textContent = `${p.update_text} - ${p.team_member} (${p.status})`;
+        progressEl.appendChild(div);
+      });
+    });
+    fetch('/api/actionItems').then(r => r.json()).then(data => {
+      data.forEach(a => {
+        const div = document.createElement('div');
+        div.textContent = `${a.item_text} - ${a.team_member} (${a.status})`;
+        actionEl.appendChild(div);
+      });
+    });
+    fetch('/api/challenges').then(r => r.json()).then(data => {
+      data.forEach(c => {
+        const div = document.createElement('div');
+        div.textContent = `${c.challenge_text} - ${c.team_member} (${c.status})`;
+        challengesEl.appendChild(div);
+      });
+    });
+    fetch('/api/priorities').then(r => r.json()).then(data => {
+      data.forEach(p => {
+        const div = document.createElement('div');
+        div.textContent = `${p.topic} - ${p.team_member}`;
+        prioritiesEl.appendChild(div);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add challenges table and API endpoint
- install express and sqlite3 via package.json
- fetch challenges in Reveal.js slides
- add seeding instructions and .gitignore

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_687e45f07f7c8328a143bdca855b46e1