### PR TITLE
Add Accounting POD weekly meeting slide deck (static HTML + IndexedDB)

### DIFF
--- a/pod-slide-deck/README.md
+++ b/pod-slide-deck/README.md
@@ -1,0 +1,21 @@
+# Accounting POD Weekly Meeting Deck
+
+This folder contains a lightweight, browser-based slide deck for weekly Accounting POD meetings. It uses IndexedDB to store meeting updates and notes locally in the browser.
+
+## Features
+- Corporate navy/light blue/white/gray theme
+- Progress, challenges, action items, and priorities slides
+- Local note-taking with persistent storage in IndexedDB
+- Inline form to add new updates during the meeting
+
+## Run Locally
+Use any static file server. For example:
+
+```bash
+npx serve .
+```
+
+Then open the provided local URL in your browser.
+
+## Data Storage
+All updates and notes are stored in IndexedDB under the `podDeckDB` database. Clearing browser data removes saved items.

--- a/pod-slide-deck/app.js
+++ b/pod-slide-deck/app.js
@@ -1,0 +1,142 @@
+const slides = Array.from(document.querySelectorAll(".slide"));
+const progressBar = document.getElementById("progressBar");
+const weekOf = document.getElementById("weekOf");
+const form = document.getElementById("entryForm");
+const formStatus = document.getElementById("formStatus");
+let currentSlide = 0;
+
+const listMap = {
+  progress: document.getElementById("progressList"),
+  challenges: document.getElementById("challengeList"),
+  actions: document.getElementById("actionList"),
+  priorities: document.getElementById("priorityList"),
+};
+
+const noteInputs = {
+  agenda: document.getElementById("agendaNote"),
+  progress: document.getElementById("progressNote"),
+  challenge: document.getElementById("challengeNote"),
+  action: document.getElementById("actionNote"),
+  priority: document.getElementById("priorityNote"),
+};
+
+function setWeekOf() {
+  const today = new Date();
+  const options = { month: "short", day: "numeric", year: "numeric" };
+  weekOf.textContent = today.toLocaleDateString(undefined, options);
+}
+
+function updateSlide(index) {
+  slides.forEach((slide, idx) => {
+    slide.classList.toggle("is-active", idx === index);
+  });
+  currentSlide = index;
+  const progress = ((index + 1) / slides.length) * 100;
+  progressBar.style.width = `${progress}%`;
+}
+
+function renderList(target, items) {
+  if (!target) return;
+  if (!items.length) {
+    target.innerHTML = "<p class=\"empty\">No updates yet. Add one on the Update slide.</p>";
+    return;
+  }
+  target.innerHTML = items
+    .map(
+      (item) => `
+      <div class="list-item">
+        <strong>${item.owner}</strong>
+        <span>${item.detail}</span>
+        <span class="status">Status: ${item.status}</span>
+      </div>
+    `
+    )
+    .join("");
+}
+
+function refreshLists() {
+  Promise.all([
+    podDB.getAllItems(podDB.storeNames.progress),
+    podDB.getAllItems(podDB.storeNames.challenges),
+    podDB.getAllItems(podDB.storeNames.actions),
+    podDB.getAllItems(podDB.storeNames.priorities),
+  ]).then(([progress, challenges, actions, priorities]) => {
+    renderList(listMap.progress, progress);
+    renderList(listMap.challenges, challenges);
+    renderList(listMap.actions, actions);
+    renderList(listMap.priorities, priorities);
+  });
+}
+
+function loadNotes() {
+  Object.entries(noteInputs).forEach(([key, input]) => {
+    podDB.getNote(key).then((content) => {
+      input.value = content;
+    });
+  });
+}
+
+function bindControls() {
+  document.getElementById("prevBtn").addEventListener("click", () => {
+    updateSlide(Math.max(0, currentSlide - 1));
+  });
+
+  document.getElementById("nextBtn").addEventListener("click", () => {
+    updateSlide(Math.min(slides.length - 1, currentSlide + 1));
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowRight") {
+      updateSlide(Math.min(slides.length - 1, currentSlide + 1));
+    }
+    if (event.key === "ArrowLeft") {
+      updateSlide(Math.max(0, currentSlide - 1));
+    }
+  });
+
+  document.querySelectorAll(".save-note").forEach((button) => {
+    button.addEventListener("click", () => {
+      const category = button.dataset.note;
+      const input = noteInputs[category];
+      const status = document.querySelector(`[data-status="${category}"]`);
+      podDB.putNote(category, input.value).then(() => {
+        if (status) {
+          status.textContent = "Saved to meeting notes.";
+          setTimeout(() => {
+            status.textContent = "";
+          }, 2000);
+        }
+      });
+    });
+  });
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const payload = {
+    owner: formData.get("owner"),
+    detail: formData.get("detail"),
+    status: formData.get("status"),
+  };
+  const category = formData.get("category");
+
+  podDB.addItem(category, payload).then(() => {
+    form.reset();
+    formStatus.textContent = "Update saved. Slides refreshed.";
+    refreshLists();
+    setTimeout(() => {
+      formStatus.textContent = "";
+    }, 2000);
+  });
+});
+
+setWeekOf();
+updateSlide(0);
+
+podDB.seedDatabase().then(() => {
+  refreshLists();
+  loadNotes();
+});
+
+bindControls();

--- a/pod-slide-deck/db.js
+++ b/pod-slide-deck/db.js
@@ -1,0 +1,141 @@
+const DB_NAME = "podDeckDB";
+const DB_VERSION = 1;
+
+const storeNames = {
+  progress: "progress",
+  challenges: "challenges",
+  actions: "actions",
+  priorities: "priorities",
+  notes: "notes",
+};
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      Object.values(storeNames).forEach((storeName) => {
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName, { keyPath: "id", autoIncrement: true });
+        }
+      });
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function addItem(storeName, payload) {
+  return openDatabase().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction(storeName, "readwrite");
+        const store = transaction.objectStore(storeName);
+        store.add({ ...payload, createdAt: new Date().toISOString() });
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      })
+  );
+}
+
+function getAllItems(storeName) {
+  return openDatabase().then((db) => {
+    const transaction = db.transaction(storeName, "readonly");
+    const store = transaction.objectStore(storeName);
+    return new Promise((resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () => resolve(request.result || []);
+      request.onerror = () => reject(request.error);
+    });
+  });
+}
+
+function putNote(category, content) {
+  return openDatabase().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction(storeNames.notes, "readwrite");
+        const store = transaction.objectStore(storeNames.notes);
+        store.put({ id: category, content, updatedAt: new Date().toISOString() });
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      })
+  );
+}
+
+function getNote(category) {
+  return openDatabase().then((db) => {
+    const transaction = db.transaction(storeNames.notes, "readonly");
+    const store = transaction.objectStore(storeNames.notes);
+    return new Promise((resolve, reject) => {
+      const request = store.get(category);
+      request.onsuccess = () => resolve(request.result ? request.result.content : "");
+      request.onerror = () => reject(request.error);
+    });
+  });
+}
+
+function seedDatabase() {
+  const seedData = {
+    progress: [
+      {
+        owner: "Audit Team",
+        detail: "Closed month-end reconciliations for three subsidiaries.",
+        status: "On Track",
+      },
+      {
+        owner: "Tax Team",
+        detail: "Drafted state tax filings and reviewed variances.",
+        status: "On Track",
+      },
+    ],
+    challenges: [
+      {
+        owner: "Advisory",
+        detail: "Awaiting client responses for revenue recognition review.",
+        status: "Needs Help",
+      },
+    ],
+    actions: [
+      {
+        owner: "All Pods",
+        detail: "Confirm Q3 deliverables and timeline assumptions.",
+        status: "On Track",
+      },
+      {
+        owner: "Compliance",
+        detail: "Prepare evidence list for upcoming internal audit.",
+        status: "At Risk",
+      },
+    ],
+    priorities: [
+      {
+        owner: "Leadership",
+        detail: "Finalize staffing model for peak month-end support.",
+        status: "On Track",
+      },
+    ],
+  };
+
+  return Promise.all(
+    Object.entries(seedData).map(([storeName, items]) =>
+      getAllItems(storeName).then((existing) => {
+        if (existing.length) {
+          return null;
+        }
+        return Promise.all(items.map((item) => addItem(storeName, item)));
+      })
+    )
+  );
+}
+
+window.podDB = {
+  storeNames,
+  addItem,
+  getAllItems,
+  putNote,
+  getNote,
+  seedDatabase,
+};

--- a/pod-slide-deck/index.html
+++ b/pod-slide-deck/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Accounting POD Weekly Meeting Deck</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app">
+    <header class="app-header">
+      <div>
+        <p class="eyebrow">Accounting POD</p>
+        <h1>Weekly Meeting Deck</h1>
+        <p class="subtitle">Progress • Challenges • Action Items • Priorities</p>
+      </div>
+      <div class="meeting-meta">
+        <div>
+          <span class="meta-label">Week Of</span>
+          <span id="weekOf"></span>
+        </div>
+        <div>
+          <span class="meta-label">Facilitator</span>
+          <span contenteditable="true" class="meta-edit">Add name</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="deck">
+      <section class="slide is-active" data-slide="0">
+        <div class="slide-content">
+          <h2>Agenda</h2>
+          <ul class="agenda">
+            <li>Team progress snapshot</li>
+            <li>Top challenges & blockers</li>
+            <li>Action items for the week</li>
+            <li>Key priorities & focus areas</li>
+          </ul>
+          <div class="note-area">
+            <label for="agendaNote">Notes</label>
+            <textarea id="agendaNote" placeholder="Capture agenda notes..."></textarea>
+            <button class="save-note" data-note="agenda">Save note</button>
+            <p class="note-status" data-status="agenda"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide" data-slide="1">
+        <div class="slide-content">
+          <div class="slide-header">
+            <div class="icon">📈</div>
+            <h2>Progress Update</h2>
+          </div>
+          <p class="slide-subtitle">Highlights of completed work and milestones.</p>
+          <div class="list" id="progressList"></div>
+          <div class="note-area">
+            <label for="progressNote">Notes</label>
+            <textarea id="progressNote" placeholder="Add notes for progress..."></textarea>
+            <button class="save-note" data-note="progress">Save note</button>
+            <p class="note-status" data-status="progress"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide" data-slide="2">
+        <div class="slide-content">
+          <div class="slide-header">
+            <div class="icon">⚠️</div>
+            <h2>Challenges & Risks</h2>
+          </div>
+          <p class="slide-subtitle">Items requiring escalation or support.</p>
+          <div class="list" id="challengeList"></div>
+          <div class="note-area">
+            <label for="challengeNote">Notes</label>
+            <textarea id="challengeNote" placeholder="Add notes for challenges..."></textarea>
+            <button class="save-note" data-note="challenge">Save note</button>
+            <p class="note-status" data-status="challenge"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide" data-slide="3">
+        <div class="slide-content">
+          <div class="slide-header">
+            <div class="icon">✅</div>
+            <h2>Action Items</h2>
+          </div>
+          <p class="slide-subtitle">Commitments for the week ahead.</p>
+          <div class="list" id="actionList"></div>
+          <div class="note-area">
+            <label for="actionNote">Notes</label>
+            <textarea id="actionNote" placeholder="Add notes for action items..."></textarea>
+            <button class="save-note" data-note="action">Save note</button>
+            <p class="note-status" data-status="action"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide" data-slide="4">
+        <div class="slide-content">
+          <div class="slide-header">
+            <div class="icon">🎯</div>
+            <h2>Weekly Priorities</h2>
+          </div>
+          <p class="slide-subtitle">Focus areas aligned to team goals.</p>
+          <div class="list" id="priorityList"></div>
+          <div class="note-area">
+            <label for="priorityNote">Notes</label>
+            <textarea id="priorityNote" placeholder="Add notes for priorities..."></textarea>
+            <button class="save-note" data-note="priority">Save note</button>
+            <p class="note-status" data-status="priority"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide" data-slide="5">
+        <div class="slide-content">
+          <div class="slide-header">
+            <div class="icon">🗂️</div>
+            <h2>Update the Deck</h2>
+          </div>
+          <p class="slide-subtitle">Add new entries to the database in real time.</p>
+          <form id="entryForm" class="entry-form">
+            <label>
+              Category
+              <select name="category" required>
+                <option value="progress">Progress</option>
+                <option value="challenges">Challenges</option>
+                <option value="actions">Action Items</option>
+                <option value="priorities">Priorities</option>
+              </select>
+            </label>
+            <label>
+              Owner
+              <input type="text" name="owner" placeholder="Team member" required />
+            </label>
+            <label>
+              Description
+              <textarea name="detail" rows="3" placeholder="Describe the update" required></textarea>
+            </label>
+            <label>
+              Status
+              <select name="status" required>
+                <option value="On Track">On Track</option>
+                <option value="Needs Help">Needs Help</option>
+                <option value="At Risk">At Risk</option>
+              </select>
+            </label>
+            <button type="submit">Save update</button>
+            <p class="form-status" id="formStatus"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="deck-controls">
+      <button id="prevBtn">Previous</button>
+      <div class="progress">
+        <div class="progress-bar" id="progressBar"></div>
+      </div>
+      <button id="nextBtn">Next</button>
+    </footer>
+  </div>
+
+  <script src="db.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/pod-slide-deck/styles.css
+++ b/pod-slide-deck/styles.css
@@ -1,0 +1,267 @@
+:root {
+  --navy: #0f2441;
+  --light-blue: #6ea8d6;
+  --white: #ffffff;
+  --gray: #f0f2f5;
+  --text: #1d2a3a;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", "Inter", sans-serif;
+}
+
+body {
+  background: var(--gray);
+  color: var(--text);
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 48px 24px;
+}
+
+.app-header {
+  background: var(--navy);
+  color: var(--white);
+  border-radius: 20px;
+  padding: 28px 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  box-shadow: 0 12px 30px rgba(15, 36, 65, 0.2);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 12px;
+  color: var(--light-blue);
+  margin-bottom: 6px;
+}
+
+.app-header h1 {
+  font-size: 32px;
+  margin-bottom: 4px;
+}
+
+.subtitle {
+  color: #c8d9ef;
+}
+
+.meeting-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 16px 20px;
+  border-radius: 14px;
+}
+
+.meta-label {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 1px;
+  display: block;
+  color: #c8d9ef;
+}
+
+.meta-edit {
+  display: inline-block;
+  padding: 4px 8px;
+  border-bottom: 1px dashed #c8d9ef;
+}
+
+.deck {
+  flex: 1;
+  position: relative;
+}
+
+.slide {
+  display: none;
+  background: var(--white);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 10px 24px rgba(15, 36, 65, 0.08);
+}
+
+.slide.is-active {
+  display: block;
+}
+
+.slide-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.slide-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.slide-header h2 {
+  font-size: 26px;
+  color: var(--navy);
+}
+
+.icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--light-blue);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+}
+
+.slide-subtitle {
+  color: #5a6b82;
+}
+
+.agenda {
+  display: grid;
+  gap: 12px;
+  font-size: 18px;
+}
+
+.list {
+  display: grid;
+  gap: 12px;
+}
+
+.list-item {
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--gray);
+  display: grid;
+  gap: 6px;
+}
+
+.list-item strong {
+  color: var(--navy);
+}
+
+.list-item .status {
+  font-size: 12px;
+  color: #5b6b7e;
+}
+
+.empty {
+  padding: 16px;
+  background: #eef2f6;
+  border-radius: 12px;
+  color: #5b6b7e;
+}
+
+.note-area {
+  border-top: 1px solid #dbe2ea;
+  padding-top: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.note-area textarea {
+  min-height: 90px;
+  resize: vertical;
+  border-radius: 10px;
+  padding: 12px;
+  border: 1px solid #cdd5de;
+}
+
+.save-note {
+  align-self: flex-start;
+  background: var(--navy);
+  color: var(--white);
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.note-status,
+.form-status {
+  font-size: 12px;
+  color: #4e5d70;
+}
+
+.entry-form {
+  display: grid;
+  gap: 16px;
+}
+
+.entry-form label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.entry-form input,
+.entry-form textarea,
+.entry-form select {
+  border: 1px solid #cdd5de;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+}
+
+.entry-form button {
+  justify-self: start;
+  background: var(--light-blue);
+  color: var(--navy);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.deck-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.deck-controls button {
+  background: var(--navy);
+  color: var(--white);
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  cursor: pointer;
+}
+
+.progress {
+  flex: 1;
+  height: 10px;
+  background: #d7dee7;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--light-blue);
+  transition: width 0.3s ease;
+}
+
+@media (max-width: 900px) {
+  .app {
+    padding: 24px;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, professional slide deck for Accounting POD weekly meetings that supports progress, challenges, action items, priorities, and in-meeting note-taking. 
- Keep the solution client-only so teams can use and persist meeting content locally without a backend by leveraging browser storage.

### Description
- Add a `pod-slide-deck` folder containing `index.html`, `styles.css`, `app.js`, `db.js`, and `README.md` that implement the slide UI, navigation, note areas, and an update form. 
- Implement a small IndexedDB wrapper in `db.js` with stores `progress`, `challenges`, `actions`, `priorities`, and `notes`, promise-based write helpers, and seeded sample data. 
- Implement frontend logic in `app.js` to render lists from the DB, bind keyboard and button navigation, save notes with `putNote`, and create updates with `addItem`. 
- Apply a corporate color scheme and responsive layout in `styles.css` and document local usage in `README.md`.

### Testing
- Performed a smoke test by serving the folder with `python -m http.server 4173` and using Playwright to load `index.html` and capture a screenshot, which completed successfully and produced `artifacts/pod-deck.png`. 
- Verified that static assets `index.html`, `styles.css`, `db.js`, and `app.js` were served successfully during the smoke test. 
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_687e44ed48cc832885b7174053cd6874)